### PR TITLE
Add mock prisma client for offline env

### DIFF
--- a/lib/mockPrisma.ts
+++ b/lib/mockPrisma.ts
@@ -1,0 +1,61 @@
+import fs from 'fs'
+import path from 'path'
+
+type User = {
+  id: string
+  name: string
+  email: string
+  passwordHash: string
+  emailConfirmed: boolean
+  gdprConsented: boolean
+  sendfoxStatus: string
+  sendfoxError: string | null
+  createdAt: string
+}
+
+const DB_FILE = path.join(process.cwd(), 'mock-db.json')
+
+function load(): User[] {
+  try {
+    return JSON.parse(fs.readFileSync(DB_FILE, 'utf8')) as User[]
+  } catch {
+    return []
+  }
+}
+
+function save(data: User[]) {
+  fs.writeFileSync(DB_FILE, JSON.stringify(data, null, 2))
+}
+
+export class MockPrisma {
+  private users: User[] = load()
+
+  user = {
+    findUnique: async ({ where }: { where: { email?: string; id?: string } }) => {
+      return (
+        this.users.find((u) =>
+          where.email ? u.email === where.email : u.id === where.id
+        ) || null
+      )
+    },
+    create: async ({ data }: { data: Omit<User, 'id' | 'createdAt'> }) => {
+      const user: User = {
+        ...data,
+        id: Date.now().toString(),
+        createdAt: new Date().toISOString(),
+      }
+      this.users.push(user)
+      save(this.users)
+      return user
+    },
+    update: async ({ where, data }: { where: { email?: string; id?: string }; data: Partial<User> }) => {
+      const user = this.users.find((u) =>
+        where.email ? u.email === where.email : u.id === where.id
+      )
+      if (!user) throw new Error('User not found')
+      Object.assign(user, data)
+      save(this.users)
+      return user
+    },
+  }
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,7 +1,15 @@
-import { PrismaClient } from '@prisma/client'
+let prisma: any
 
-const globalForPrisma = global as unknown as { prisma?: PrismaClient }
+try {
+  // Try to load the actual Prisma Client if installed
+  const { PrismaClient } = require('@prisma/client')
+  const globalForPrisma = global as unknown as { prisma?: typeof PrismaClient }
+  prisma = globalForPrisma.prisma ?? new PrismaClient()
+  if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+} catch (err) {
+  // Fallback to a lightweight mock implementation
+  const { MockPrisma } = require('./mockPrisma')
+  prisma = new MockPrisma()
+}
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient()
-
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+export { prisma }


### PR DESCRIPTION
## Summary
- add a lightweight mock Prisma client storing data in `mock-db.json`
- fallback to this mock when `@prisma/client` is unavailable

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845af1925fc83329fa53dd45d0a30ae