### PR TITLE
Add dismissible email banner

### DIFF
--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,10 +1,37 @@
+import { useEffect, useState } from 'react';
 import { withAuthPage } from '@/lib/withAuthPage';
-import UserDropdown from '@/components/UserDropdown';
 import ProtectedLayout from '@/components/ProtectedLayout';
 
 const Dashboard = ({ user }: { user: { id: string; email: string } }) => {
+  const [showBanner, setShowBanner] = useState(false);
+
+  useEffect(() => {
+    const hasLoggedIn = localStorage.getItem('hasLoggedIn');
+    const dismissed = localStorage.getItem('confirmationBannerDismissed');
+    if (hasLoggedIn && !dismissed) {
+      setShowBanner(true);
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    setShowBanner(false);
+    localStorage.setItem('confirmationBannerDismissed', 'true');
+  };
+
   return (
     <ProtectedLayout user={user}>
+      {showBanner && (
+        <div className="relative mb-4 rounded border border-blue-300 bg-blue-100 px-4 py-3 text-blue-900">
+          <p>Please check your email for a confirmation message.</p>
+          <button
+            onClick={handleDismiss}
+            className="absolute right-2 top-2 text-lg leading-none"
+            aria-label="Dismiss"
+          >
+            &times;
+          </button>
+        </div>
+      )}
       <h2 className="text-xl font-bold mb-4">Dashboard</h2>
       <p>Burn rate data and dawah tools will appear here.</p>
     </ProtectedLayout>

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -28,6 +28,9 @@ const Login: NextPage = () => {
       });
 
       if (!res.ok) throw new Error('Invalid credentials');
+      if (!localStorage.getItem('hasLoggedIn')) {
+        localStorage.setItem('hasLoggedIn', 'true');
+      }
       router.push('/dashboard');
     } catch (err) {
       setError('Login failed. Please check your credentials.');


### PR DESCRIPTION
## Summary
- show email confirmation banner on first login
- mark first login in localStorage to trigger banner

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a4d4d28c8332814359a5c316d48d