### PR TITLE
Add geolocation capture on auth

### DIFF
--- a/pages/api/login.tsx
+++ b/pages/api/login.tsx
@@ -7,7 +7,7 @@ import { serialize } from 'cookie';
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).json({ message: 'Method Not Allowed' });
 
-  const { email, password } = req.body;
+  const { email, password, location_city, location_country } = req.body;
   if (!email || !password) {
     return res.status(400).json({ message: 'Missing email or password.' });
   }
@@ -18,6 +18,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const isValid = await bcrypt.compare(password, user.passwordHash);
     if (!isValid) return res.status(401).json({ message: 'Invalid credentials' });
+
+    await prisma.user.update({
+      where: { id: user.id },
+      data: {
+        location_city,
+        location_country,
+      },
+    });
 
     // Create JWT token
     const token = jwt.sign(

--- a/pages/api/signup.tsx
+++ b/pages/api/signup.tsx
@@ -5,7 +5,14 @@ import bcrypt from 'bcryptjs';
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end('Method Not Allowed');
 
-  const { name, email, password, gdprConsented } = req.body;
+  const {
+    name,
+    email,
+    password,
+    gdprConsented,
+    location_city,
+    location_country,
+  } = req.body;
 
 
   if (!name || !email || !password || gdprConsented !== true) {
@@ -30,6 +37,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         passwordHash,
         gdprConsented,
         emailConfirmed: false,
+        location_city,
+        location_country,
       },
     });
 

--- a/prisma/migrations/20250608145851_add_location/migration.sql
+++ b/prisma/migrations/20250608145851_add_location/migration.sql
@@ -1,0 +1,22 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
+    "emailConfirmed" BOOLEAN NOT NULL DEFAULT false,
+    "gdprConsented" BOOLEAN NOT NULL,
+    "sendfoxStatus" TEXT NOT NULL DEFAULT 'pending',
+    "sendfoxError" TEXT,
+    "location_city" TEXT,
+    "location_country" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO "new_User" ("createdAt", "email", "emailConfirmed", "gdprConsented", "id", "name", "passwordHash", "sendfoxStatus", "sendfoxError") SELECT "createdAt", "email", "emailConfirmed", "gdprConsented", "id", "name", "passwordHash", "sendfoxStatus", "sendfoxError" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,5 +17,7 @@ model User {
   gdprConsented Boolean
   sendfoxStatus  String   @default("pending") // "pending" | "success" | "failed"
   sendfoxError   String?  // optional error message
+  location_city String?
+  location_country String?
   createdAt     DateTime @default(now())
 }


### PR DESCRIPTION
## Summary
- capture browser location on signup and login
- store city and country fields in database
- add migration for location columns

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a4d0f2688332bdc17e45e5d273b6