### PR TITLE
Add privacy and terms pages

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -45,8 +45,17 @@ const Home: NextPage = () => {
         .
       </div>
 
-      <footer className="mt-16 text-xs text-slate-400">
-        &copy; {new Date().getFullYear()} UmmahBuilders. All rights reserved.
+      <footer className="mt-16 text-xs text-slate-400 flex flex-col items-center gap-2">
+        <span>&copy; {new Date().getFullYear()} UmmahBuilders. All rights reserved.</span>
+        <div className="flex gap-4">
+          <Link href="/privacy" className="underline hover:text-slate-600">
+            Privacy Policy
+          </Link>
+          <span>|</span>
+          <Link href="/terms" className="underline hover:text-slate-600">
+            Terms of Service
+          </Link>
+        </div>
       </footer>
     </main>
   );

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -1,0 +1,23 @@
+import { NextPage } from 'next';
+import Link from 'next/link';
+
+const Privacy: NextPage = () => {
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Privacy Policy</h1>
+      <p>
+        This page will contain our full privacy policy. For now, it serves as a
+        placeholder describing how user data is handled.
+      </p>
+      <p>
+        Return to the{' '}
+        <Link href="/" className="underline">
+          home page
+        </Link>
+        .
+      </p>
+    </main>
+  );
+};
+
+export default Privacy;

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -74,13 +74,20 @@ const Signup: NextPage = () => {
             <Input type="password" placeholder="Confirm Password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} />
 
             <div className="flex items-center gap-2">
-              <Checkbox id="gdpr" checked={gdprConsented} onCheckedChange={(checked) => setGdprConsented(checked === true)} />
+              <Checkbox
+                id="gdpr"
+                checked={gdprConsented}
+                onCheckedChange={(checked) => setGdprConsented(checked === true)}
+              />
               <label htmlFor="gdpr" className="text-sm">
                 I consent to the{' '}
                 <Link href="/privacy" className="underline">
                   Privacy Policy
+                </Link>{' '}
+                and{' '}
+                <Link href="/terms" className="underline">
+                  Terms of Service
                 </Link>
-                
               </label>
             </div>
 

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -1,0 +1,23 @@
+import { NextPage } from 'next';
+import Link from 'next/link';
+
+const Terms: NextPage = () => {
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Terms of Service</h1>
+      <p>
+        The full terms of service will be published here. This placeholder outlines
+        the basic conditions for using the application.
+      </p>
+      <p>
+        Return to the{' '}
+        <Link href="/" className="underline">
+          home page
+        </Link>
+        .
+      </p>
+    </main>
+  );
+};
+
+export default Terms;


### PR DESCRIPTION
## Summary
- add placeholder pages for privacy policy and terms of service
- link to the new pages from the landing page footer
- update sign-up form consent text with links to privacy and terms

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a4c46bf483329ef8786b6ebbcb28