### PR TITLE
Add dashboard navigation and settings

### DIFF
--- a/components/ProtectedLayout.tsx
+++ b/components/ProtectedLayout.tsx
@@ -9,7 +9,7 @@ type ProtectedLayoutProps = {
 const ProtectedLayout = ({ user, children }: ProtectedLayoutProps) => {
   return (
     <div className="min-h-screen bg-slate-50">
-      <header className="flex justify-between items-center px-6 py-4 bg-white shadow-sm border-b">
+      <header className="flex justify-between items-center px-6 py-4 bg-gradient-to-r from-green-100 to-green-200 shadow-sm border-b">
         <h1 className="text-lg font-semibold text-slate-700">
           Ummah Builder's Burn Rate App
         </h1>

--- a/components/UserDropdown.tsx
+++ b/components/UserDropdown.tsx
@@ -28,10 +28,16 @@ const UserDropdown = ({ email }: { email: string }) => {
           <Link href="/dashboard">Dashboard</Link>
         </DropdownMenu.Item>
         <DropdownMenu.Item className="py-2 px-3 hover:bg-slate-100 rounded-md">
+          <Link href="/burn-rate-calculator">Calculator</Link>
+        </DropdownMenu.Item>
+        <DropdownMenu.Item className="py-2 px-3 hover:bg-slate-100 rounded-md">
           <Link href="/referrals">Referrals</Link>
         </DropdownMenu.Item>
         <DropdownMenu.Item className="py-2 px-3 hover:bg-slate-100 rounded-md">
           <Link href="/profile">Profile</Link>
+        </DropdownMenu.Item>
+        <DropdownMenu.Item className="py-2 px-3 hover:bg-slate-100 rounded-md">
+          <Link href="/settings">Settings</Link>
         </DropdownMenu.Item>
         <DropdownMenu.Separator className="h-px bg-slate-200 my-2" />
         <DropdownMenu.Item

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { withAuthPage } from '@/lib/withAuthPage';
 import ProtectedLayout from '@/components/ProtectedLayout';
+import Link from 'next/link';
+import { User, Calculator, Cog, Users } from 'lucide-react';
 
 const Dashboard = ({ user }: { user: { id: string; email: string } }) => {
   const [showBanner, setShowBanner] = useState(false);
@@ -33,7 +35,48 @@ const Dashboard = ({ user }: { user: { id: string; email: string } }) => {
         </div>
       )}
       <h2 className="text-xl font-bold mb-4">Dashboard</h2>
-      <p>Burn rate data and dawah tools will appear here.</p>
+      <div className="grid gap-6 md:grid-cols-2">
+        <Link
+          href="/profile"
+          className="flex items-center gap-4 p-4 bg-white border rounded-lg shadow hover:bg-slate-50 transition"
+        >
+          <User className="w-6 h-6 text-green-600" />
+          <div>
+            <h3 className="font-semibold">Profile</h3>
+            <p className="text-sm text-muted-foreground">Manage your account</p>
+          </div>
+        </Link>
+        <Link
+          href="/burn-rate-calculator"
+          className="flex items-center gap-4 p-4 bg-white border rounded-lg shadow hover:bg-slate-50 transition"
+        >
+          <Calculator className="w-6 h-6 text-green-600" />
+          <div>
+            <h3 className="font-semibold">Calculator</h3>
+            <p className="text-sm text-muted-foreground">Plan your burn rate</p>
+          </div>
+        </Link>
+        <Link
+          href="/referrals"
+          className="flex items-center gap-4 p-4 bg-white border rounded-lg shadow hover:bg-slate-50 transition"
+        >
+          <Users className="w-6 h-6 text-green-600" />
+          <div>
+            <h3 className="font-semibold">Referrals</h3>
+            <p className="text-sm text-muted-foreground">Invite your friends</p>
+          </div>
+        </Link>
+        <Link
+          href="/settings"
+          className="flex items-center gap-4 p-4 bg-white border rounded-lg shadow hover:bg-slate-50 transition"
+        >
+          <Cog className="w-6 h-6 text-green-600" />
+          <div>
+            <h3 className="font-semibold">Settings</h3>
+            <p className="text-sm text-muted-foreground">Configure the app</p>
+          </div>
+        </Link>
+      </div>
     </ProtectedLayout>
   );
 };

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -1,0 +1,17 @@
+import { withAuthPage } from '@/lib/withAuthPage';
+import ProtectedLayout from '@/components/ProtectedLayout';
+
+const SettingsPage = ({ user }: { user: { id: string; email: string } }) => {
+  return (
+    <ProtectedLayout user={user}>
+      <h2 className="text-xl font-bold mb-4">Settings</h2>
+      <p>Update your account preferences here.</p>
+    </ProtectedLayout>
+  );
+};
+
+export const getServerSideProps = withAuthPage(async (_ctx, user) => {
+  return { props: { user } };
+});
+
+export default SettingsPage;


### PR DESCRIPTION
## Summary
- add links in user dropdown for calculator and settings
- display navigation cards on dashboard for Profile, Calculator, Referrals and Settings
- add simple Settings page
- style header with a gradient

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: packages missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845b7c722e08332ad5ead35b0818a62